### PR TITLE
README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please see Apple's documentation on [file system basics](https://developer.apple
 This is an intended replacement for when Apple removes `/usr/bin/python`
 
 ## Using interactively
-After installing any of the packages, a symbolic link can be used within terminal for interactive python sessions. At the time of this writing `/usr/local/bin/python3.framework` points to `/Library/SystemFrameworks/Python3.framework/Versions/3.8/bin/python3.8`
+After installing any of the packages, a symbolic link can be used within terminal for interactive Python sessions. At the time of this writing `/usr/local/bin/python3.framework` points to `/Library/SystemFrameworks/Python3.framework/Versions/3.8/bin/python3.8`
 
 ## Using with scripts
 Careful consideration should be used when determining the best course of action for using with scripts. Due to various complexities, a shim file has been provided and is located at `/Library/SystemFrameworks/Python3.framework/python3`
@@ -25,66 +25,66 @@ print('This is an example script.')
 
 ### Other options to consider
 #### zshenv global alias
-If you are calling python within zsh scripts, adding a global alias to `/etc/zshenv` may be appropriate.
+If you are calling `python` within `zsh` scripts, adding a global alias to `/etc/zshenv` may be appropriate.
 
 `alias -g python3.framework='/Library/SystemFrameworks/Python3.framework/python3'`
 
-For more information on this method, please see Moving to Zsh Part [II](https://scriptingosx.com/2019/06/moving-to-zsh-part-2-configuration-files/) and [IV](https://scriptingosx.com/2019/07/moving-to-zsh-part-4-aliases-and-functions/)
+For more information on this method, please see Armin Briegel's "Moving to Zsh" Part [II](https://scriptingosx.com/2019/06/moving-to-zsh-part-2-configuration-files/) and [IV](https://scriptingosx.com/2019/07/moving-to-zsh-part-4-aliases-and-functions/)
 
 ## Notes
 To decrease complexity, only a _single_ package may be installed at any given time on a machine.
 
 ### Upgrades
-While Python itself has it's own update cadence and dot release schedule, it is likely that this package will have many updates as 3rd party libraries release their own updates, bug fixes and security enhancements. These packages should not break your workflow, but you should test your scripts prior to wide deployment to your devices.
+While Python itself has its own update cadence and dot release schedule, it is likely that this package will have many updates as 3rd party libraries release their own updates, bug fixes and security enhancements. These packages should not break your workflow, but you should test your scripts prior to wide deployment to your devices.
 
 ### Downgrades
 Downgrades will not be supported by this repository.
 
 ### pip
-While `pip` is bundled in this framework, it is **not recommended** to install any external libraries into your frameworks folder outside of what comes with the package. If you need to use or test external libraries not present in the package, it is recommended to use a virtual environment or a tool like [pyenv](https://github.com/pyenv/pyenv).
+While `pip` is bundled in this framework, it is **not recommended** to install any external libraries into your frameworks folder outside of what comes with the package. If you need to use or test external libraries not present in the package, it is recommended to use a [virtual environment](https://docs.python.org/3/library/venv.html) or a tool like [pyenv](https://github.com/pyenv/pyenv).
 
-Pull Requests can be issued to the `opinionated` or `recommended` package, but more scrutiny will be applied to the `recommended` package.
+Pull requests can be issued to the `opinionated` or `recommended` packages, but more scrutiny will be applied to the `recommended` package.
 
 # Flavors of Python
 We currently offer four versions of Python. You can chose which version suits your needs.
-
-## Minimal
-This is a Python.framework that includes `xattr` and `PyObjc` - the original intent of Relocatable Python.
-
-Tools that should work
-- vfuse
-- dockutil (python 3 pull request [here](https://github.com/kcrawford/dockutil/pull/87))
-- outset
 
 ## No Customization
 This is a Python.framework that contains everything from the official Python package and nothing more.
 
 Many open source tools will not work with this, but it may be helpful for development purposes.
 
-## Recommended
-This is a Python.framework that contains everything from minimal, and a few libraries that various well known open source projects require.
+## Minimal
+This is a Python.framework that includes `xattr` and `PyObjc` - the original intent of [Relocatable Python](https://github.com/gregneagle/relocatable-python).
 
-Tools that should work:
-- autopkg
-- InstallApplications
-- munki
-- munki-pkg
-- munki-facts (python 3 pull request [here](https://github.com/munki/munki-facts/pull/17))
-- nudge
-- UMAD
+Tools that should work when using the "Minimal Flavor":
+- [vfuse](https://github.com/chilcote/vfuse)
+- [dockutil](https://github.com/kcrawford/dockutil) (Python 3 pull request [here](https://github.com/kcrawford/dockutil/pull/87))
+- [outset](https://github.com/chilcote/outset)
+
+## Recommended
+This is a Python.framework that contains everything from "Minimal", and a few libraries that various well-known open source projects require.
+
+Tools that should work when using the "Recommended Flavor":
+- [Autopkg](https://github.com/autopkg/autopkg)
+- [InstallApplications](https://github.com/macadmins/installapplications)
+- [Munki](https://github.com/munki/munki)
+- [munkipkg](https://github.com/munki/munki-pkg)
+- [munki-facts](https://github.com/munki/munki-facts) (python 3 pull request [here](https://github.com/munki/munki-facts/pull/17))
+- [Nudge](https://github.com/macadmins/nudge)
+- [UMAD](https://github.com/macadmins/umad)
 
 ## Opinionated
-This is a Python.framework that contains everything from Recommended, and libraries that various open source projects require.
+This is a Python.framework that contains everything from "Recommended", and libraries that various open source projects require.
 
 This is a **kitchen sink** approach, opting for the latest known packages.
 
-Tools that should work:
-- Gusto's autopkg promotion tool
-- Munki CloudFront Middleware
-- Python-jss
+Tools that should work when using the "Opinionated Flavor":
+- [Gusto's AutoPkg promotion tool](https://github.com/Gusto/it-cpe-opensource/tree/master/autopromote)
+- [Munki CloudFront Middleware](https://github.com/AaronBurchfield/CloudFront-Middleware)
+- [Python-jss](https://github.com/jssimporter/python-jss)
 
 # Updating packages
-This should be done in a clean virtual environment. After every python package install, you can run `pip freeze | xargs pip uninstall -y` to cleanup the environment.
+This should be done in a clean virtual environment. After every Python package install, you can run `pip freeze | xargs pip uninstall -y` to cleanup the environment.
 
 # Credits
 These packages are created with two other open source tools:


### PR DESCRIPTION
- Casing: Change case/formatting of Python in various places
- Credit where credit is due: Credit Armin for his "Moving to zsh" series
- Typo: Just as my English teacher taught me, "Possessive 'its' never splits!"
- Hyperlink: Cross-link "virtual environment" to the `venv` lib docs
- Hyperlink: Cross-link vfuse, outset, and dockutil to their respective project pages
- Hyperlink: Cross-link "Relocatable Python" to Greg's project page
- Flavor Ordering: Move "No Customization" flavor above "Minimal" flavor so as one reads through the list of flavors, they increases in amount of libraries included
- Hyperlink: Cross-link AutoPkg, InstallApplications, munkipkg, munki-facts, Nudge, and UMAD to their respective project pages
- Hyperlink: Cross-link Gusto's AutoPkg promotion tool, Munki CloudFront Middleware, and Python-jss to their respective project pages